### PR TITLE
Handle range headers

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -300,11 +300,11 @@ Request.prototype.setCache = function setCache (path, cacheKeyPostfix, res, body
  * otherwise concats array onto aggregate.
  */
 Request.prototype.updateAggregate = function updateAggregate (aggregate) {
-  if (typeof aggregate === 'object') {
-    this.aggregate = aggregate;
-  } else {
+  if (aggregate instanceof Array) {
     this.aggregate || (this.aggregate = []);
     this.aggregate = this.aggregate.concat(aggregate);
+  } else {
+    this.aggregate = aggregate;
   }
 }
 


### PR DESCRIPTION
In order to handle range headers (and caching with them), a request needs to make requests recursively, keeping an internal record of the next `Next-Range` header to be sent, as well as an aggregate of response bodies.
