### PR TITLE
Fetch schema at runtime

### DIFF
--- a/lib/heroku.js
+++ b/lib/heroku.js
@@ -1,4 +1,5 @@
-var Request = require('./request');
+var Request = require('./request'),
+    q       = require('q');
 
 module.exports = Heroku;
 
@@ -17,6 +18,25 @@ Heroku.configure = function configure (config) {
   }
 
   return this;
+}
+
+Heroku.loadCurrentSchema = function loadCurrentSchema (callback) {
+  var deferred = q.defer();
+
+  Request.request({
+    path: '/schema'
+  }, function (err, schema) {
+    if (err) {
+      if (callback) callback(err);
+      return deferred.reject(err);
+    } else {
+      require('./resourceBuilder').build(schema);
+      if (callback) callback();
+      return deferred.resolve();
+    }
+  });
+
+  return deferred.promise;
 }
 
 Heroku.request = Request.request;

--- a/lib/resourceBuilder.js
+++ b/lib/resourceBuilder.js
@@ -3,7 +3,11 @@ var Heroku     = require('./heroku'),
     resources  = require('./schema').definitions;
 
 
-exports.build = function () {
+exports.build = function (currentSchema) {
+  if (currentSchema) {
+    resources = currentSchema.definitions;
+  }
+
   for (var key in resources) {
     buildResource(resources[key]);
   }


### PR DESCRIPTION
:bee: :bee: :bee:
Don't ship, yet.
:bee: :bee: :bee:

This is an experimental feature whereby the current API schema can be loaded at runtime:

``` javascript
var Heroku = require('heroku'),
    heroku = new Heroku({ token: process.env.HEROKU_API_TOKEN });

Heroku.loadCurrentSchema(function (err) {
  // `err` indicates that the schema failed to load. Ignoring it
  // will fall back to the vendored schema.
  if (err) throw err;

  heroku.apps().list(function (err, apps) {
    // etc.
  });
});
```

I'm not entirely sure this is a worthwhile feature, but I'm leaving the PR here so that I don't forget about it entirely. It still needs tests, validation, etc.

This would probably be better implemented by immediately fetching schema when the module is loaded and creating a global schema promise for the entire module that the `request` function gets called after.
