### PR TITLE
Always set a Content-Length header, even if it's 0.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -161,7 +161,10 @@ Request.prototype.handleResponse = function handleResponse (res) {
  * an appropriate 'Content-length' header.
  */
 Request.prototype.writeBody = function writeBody (req) {
-  if (!this.options.body) return;
+  if (!this.options.body) {
+    req.setHeader('Content-length', 0);
+    return;
+  }
 
   var body = JSON.stringify(this.options.body);
 

--- a/spec/lib/requestSpec.js
+++ b/spec/lib/requestSpec.js
@@ -47,6 +47,15 @@ describe('request', function() {
     });
   });
 
+  it('sets the Content-length to 0 when a body is not present', function(done) {
+    spyOn(MockRequest.prototype, 'setHeader');
+
+    makeRequest('/apps/example/collaborators/bob%40example.com', { method: 'DELETE' }, function() {
+      expect(MockRequest.prototype.setHeader).toHaveBeenCalledWith('Content-length', 0);
+      done();
+    });
+  });
+
   describe('when using an HTTP proxy', function() {
     beforeEach(function() {
       process.env.HEROKU_HTTP_PROXY_HOST='localhost:5000';


### PR DESCRIPTION
I was getting 411 Length Required errors from Heroku when trying to delete a collaborator.  Setting the Content-length header to 0 if the request has no body appears to fix it.  Spec included.
