### PR TITLE
allow custom range

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -23,7 +23,8 @@ function Request(options, callback) {
   this.host     = options.host || 'api.heroku.com';
   this.callback = callback;
   this.deferred = q.defer();
-  this.nextRange = 'id ]..; max=1000';
+  this.nextRange = options.range || 'id ]..; max=1000';
+  this.range = options.range;
 }
 
 
@@ -239,7 +240,7 @@ Request.prototype.handleSuccess = function handleSuccess(res, buffer) {
 
   this.setCache(res, body);
 
-  if (res.headers['next-range']) {
+  if (res.headers['next-range'] && !this.range) {
     this.nextRequest(res.headers['next-range'], body);
   } else {
     this.updateAggregate(body);


### PR DESCRIPTION
This allows you to pass in `range` as a custom option. Currently if you try and override the range header it causes an infinite loop.
