### PR TITLE
Allow a a passed options.auth to be used instead of the token.

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -89,7 +89,7 @@ Request.prototype.performRequest = function performRequest(cachedResponse) {
   }
 
   defaultRequestOptions = {
-    auth: ':' + this.options.token,
+    auth: this.options.auth || ':' + this.options.token,
     method: this.options.method || 'GET',
     headers: headers
   };

--- a/spec/lib/requestSpec.js
+++ b/spec/lib/requestSpec.js
@@ -176,6 +176,13 @@ describe('request', function() {
       });
     });
 
+    it('uses auth if provided explicitly', function(done) {
+      makeRequest('/apps', { auth: 'user:pass'}, function() {
+        expect(https.request.mostRecentCall.args[0].auth).toEqual('user:pass');
+        done();
+      });
+    });
+
     it('GETs by default', function(done) {
       makeRequest('/apps', {}, function() {
         expect(https.request.mostRecentCall.args[0].method).toEqual('GET');


### PR DESCRIPTION
I need this so I can "log in" via the client (e.g. duplicate what `heroku login`
does); the workflow there is to hit `/ouath/authorizations` with a
username/password in basic auth, which then provides the oauth token to be used.