### PR TITLE
Fix for infinite requests if options.headers['Range'] was already set

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -294,6 +294,8 @@ Request.prototype.handleSuccess = function handleSuccess(res, buffer) {
 Request.prototype.nextRequest = function nextRequest(nextRange, body) {
   this.updateAggregate(body);
   this.nextRange = nextRange;
+  // The initial range header passed in is no longer valid, and should no longer take precedence
+  delete (this.options.headers['Range']);
   this.request();
 };
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -294,8 +294,8 @@ Request.prototype.handleSuccess = function handleSuccess(res, buffer) {
 Request.prototype.nextRequest = function nextRequest(nextRange, body) {
   this.updateAggregate(body);
   this.nextRange = nextRange;
-  // The initial range header passed in is no longer valid, and should no longer take precedence
-  delete (this.options.headers['Range']);
+  // The initial range header passed in (if there was one), is no longer valid, and should no longer take precedence
+  delete (this.options.headers.Range);
   this.request();
 };
 


### PR DESCRIPTION
If a range header is set in the initial request options, and a subsequent request is necessary
to retrieve the rest of the range, previously the original Range header would take precedence
over `this.nextRange`, meaning the same range would be requested in an infinite loop.

Note that this modifies the origins `options.headers` object. Is this isn't desirable, the options
 can be cloned at construction or modification time.

Discovered in heroku/heroku#1462