### PR TITLE
simplify next range value for requests

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -32,7 +32,7 @@ function Request(options, callback) {
   this.deferred   = q.defer();
   this.userAgent  = options.userAgent || 'node-heroku-client/' + pjson.version;
   this.parseJSON  = options.hasOwnProperty('parseJSON') ? options.parseJSON : true;
-  this.nextRange  = 'id ]..; max=1000';
+  this.nextRange  = 'id ..; max=1000';
   this.logger     = options.logger;
   this.cache      = options.cache;
   this.middleware = options.middleware || function (_, cb) {cb();};


### PR DESCRIPTION
This simplified value is technically more correct and avoids some edge cases which currently 500 in API code.