### PR TITLE
Use req.getHeaders instead of req._headers (deprecated)

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -169,8 +169,9 @@ class Request {
   logRequest (req) {
     debug(`--> ${req.method} ${this.options.path}`)
     if (this.debug) console.error('--> ' + req.method + ' ' + req.path)
-    if (!req._headers) return
-    let headers = renderHeaders(req._headers)
+    let reqHeaders = req.getHeaders ? req.getHeaders() : req._headers // .getHeaders isn't defined in node versions < 8
+    if (!reqHeaders) return
+    let headers = renderHeaders(reqHeaders)
     debugHeaders('\n' + headers)
     if (this.debugHeaders) console.error(headers)
   }


### PR DESCRIPTION
Fixes #93.